### PR TITLE
refactor(accounts_controller.py)allow users to input expected delivery date

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2734,6 +2734,8 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 		if d.get("schedule_date") and parent_doctype == "Purchase Order":
 			child_item.schedule_date = d.get("schedule_date")
+		if d.get("expected_delivery_date") and parent_doctype == "Purchase Order":
+			child_item.expected_delivery_date = d.get("expected_delivery_date")
 
 		if str(parent).find('BlanketOrder') == -1:
 			if flt(child_item.price_list_rate):

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -517,7 +517,14 @@ erpnext.utils.update_child_items = function(opts) {
 			in_list_view: 1,
 			label: __("Reqd By Date")
 		})
-	}
+	} else if (frm.doc.doctype == "Purchase Order"){
+        fields.splice(2,0, {
+            fieldtype: 'Date',
+			fieldname: "expected_delivery_date",
+			in_list_view: 1,
+			label: __("Expected Delivery Date")
+        })
+    }
 
 	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
@@ -565,6 +572,7 @@ erpnext.utils.update_child_items = function(opts) {
 				"item_code": d.item_code,
 				"reqd_by_date": d.reqd_by_date,
 				"delivery_date": d.delivery_date,
+                "expected_delivery_date": d.expected_delivery_date,
 				"schedule_date": d.schedule_date,
 				"conversion_factor": d.conversion_factor,
 				"qty": d.qty,


### PR DESCRIPTION
ref https://app.asana.com/0/home/1202488269211191/1206998768470037

Changes: Purchase Order, child table (items) no longer allowed_on_submit. 

Context: 
When adding an item using the Update Item button, the modal does not ask for the "Expected Delivery Date" This is added when the item is already in the child table. Since we're removing this feature to directly edit the child table. "Expected Delivery Date" is now also in the modal.


![image](https://github.com/newmatik/eso-erpnext/assets/85614308/9cebfbb7-53bd-4ca1-9528-708163dbf928)
