### PR TITLE
fix(item.py): allow customer parts to have valuation rates

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -136,8 +136,6 @@ class Item(Document):
 		if self.is_customer_provided_item:
 			if self.is_purchase_item:
 				frappe.throw(_('"Customer Provided Item" cannot be Purchase Item also'))
-			if self.valuation_rate:
-				frappe.throw(_('"Customer Provided Item" cannot have Valuation Rate'))
 			self.default_material_request_type = "Customer Provided"
 
 	def add_price(self, price_list=None):


### PR DESCRIPTION
## Task
[Fix frappe.exceptions.ValidationError: "Customer Provided Item" cannot have Valuation Rate](https://app.asana.com/0/470954171642662/1208753594301196/f)

### beluga.crons.item_image_update
```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 147, in execute_job
    retval = method(**kwargs)
  File "apps/beluga/beluga/crons.py", line 39, in item_image_update
    item_doc.save()
  File "apps/frappe/frappe/model/document.py", line 312, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 349, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1054, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 943, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1264, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1246, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 940, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/doctype/item/item.py", line 113, in validate
    self.validate_customer_provided_part()
  File "apps/erpnext/erpnext/stock/doctype/item/item.py", line 140, in validate_customer_provided_part
    frappe.throw(_('"Customer Provided Item" cannot have Valuation Rate'))
  File "apps/frappe/frappe/__init__.py", line 504, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 479, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 434, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: "Customer Provided Item" cannot have Valuation Rate
```

## Background
In 2018 and in core ERPNext, customer items are not allowed to have Valuation Rates (https://github.com/frappe/erpnext/pull/15828).

However, at Newmatik, we now have customers (e.g. MVT) that require us to track the value of the parts and include them in the documents (e.g. QTN, SO, DN, etc.).

With this, our new business requirement is to allow customer parts to have valuation rates.

## Changes
- Remove the validation that prevents "Customer Provided Items" from having a Valuation Rate.